### PR TITLE
Add invoice entry date (salesinvoiceeventdate) as an attribute to sales invoice

### DIFF
--- a/lib/netvisor/sales_invoice.rb
+++ b/lib/netvisor/sales_invoice.rb
@@ -186,6 +186,7 @@ module Netvisor
       element :invoice_number, String, :tag => 'SalesInvoiceNumber'
       element :invoice_date, InvoiceDate, :tag => 'SalesInvoiceDate'
       element :invoice_due_date, InvoiceDate, :tag => 'salesinvoiceduedate'
+      element :invoice_entry_date, InvoiceDate, :tag => 'salesinvoiceeventdate'
       element :invoice_delivery_date, InvoiceDate, :tag => 'SalesInvoiceDeliveryDate'
       element :reference_number, String, :tag => 'SalesInvoiceReferenceNumber'
       element :invoice_amount, InvoiceAmount, :tag => 'SalesInvoiceAmount'


### PR DESCRIPTION
This is the attribute: https://support.netvisor.fi/fi/support/solutions/articles/77000554152-myyntilaskun-tai-tilauksen-tuonti-salesinvoice-nv#:~:text=salesinvoiceeventdate

I need it for the utilities invoice (https://kiskolabs.slack.com/archives/CQUBNRDUK/p1718805729819379?thread_ts=1717145648.302139&cid=CQUBNRDUK)